### PR TITLE
Fix mobile overflow in controls layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -173,6 +173,7 @@ main {
 
 .controls {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 24px;
   background: rgba(18, 22, 27, 0.9);
   backdrop-filter: var(--blur-glass);
@@ -201,9 +202,10 @@ main {
   border-color: var(--border-light);
 }
 
-.field { 
-  display: grid; 
-  gap: 8px; 
+.field {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
 }
 
 label { 
@@ -530,6 +532,22 @@ input[type="file"].processing::after {
     gap: 8px;
   }
 
+  .controls input[type="text"],
+  .controls input[type="password"],
+  .controls input[type="number"],
+  .controls input[type="file"],
+  .controls textarea,
+  .controls select,
+  .controls button {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .controls button {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
   progress {
     width: 100%;
     max-width: 280px;
@@ -689,9 +707,9 @@ input[type="file"].processing::after {
   border: 1px solid var(--border);
 }
 
-progress { 
-  width: 320px; 
-  height: 8px; 
+progress {
+  width: min(100%, 320px);
+  height: 8px;
   border-radius: 4px;
   overflow: hidden;
   background: rgba(31, 38, 48, 0.8);


### PR DESCRIPTION
## Summary
- constrain the controls grid to a single responsive column so its children can shrink on small screens
- let field groups collapse by default and ensure form controls expand to the available width on handheld devices
- make the progress bar width responsive so the status strip no longer contributes to horizontal scrolling

## Testing
- python3 -m http.server 8000 (manual Playwright inspection)

------
https://chatgpt.com/codex/tasks/task_e_68d4655ac12483339e3634e122296cde