### PR TITLE
Add native video filter option for model list

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,10 @@
                                     <option value="chronological" selected>By Release</option>
                                 </select>
                                 <input type="text" id="modelSearch" placeholder="Search models...">
+                                <label class="model-filter-toggle">
+                                    <input type="checkbox" id="videoFilter">
+                                    <span>Native video only</span>
+                                </label>
                             </div>
                             <div id="modelOptions" class="model-options-list"></div>
                         </div>

--- a/src/script.js
+++ b/src/script.js
@@ -62,6 +62,7 @@
     modelSearch: el('modelSearch'),
     modelOptions: el('modelOptions'),
     sortOrder: el('sortOrder'),
+    videoFilter: el('videoFilter'),
     reasoningToggle: el('reasoningToggle'),
     reasoningToggleField: el('reasoningToggleField'),
     modeToggle: el('modeToggle'),
@@ -2055,13 +2056,15 @@ Instructions: ${systemPrompt}`;
     const provider = ui.providerFilter?.value || 'all';
     const searchTerm = (ui.modelSearch?.value || '').toLowerCase();
     const sortOrder = ui.sortOrder?.value || 'chronological';
+    const videoOnly = ui.videoFilter?.checked || false;
 
     let filteredModels = state.models.filter(model => {
       const modelProvider = getModelProvider(model.id, model);
       const matchesProvider = provider === 'all' || modelProvider === provider;
       const matchesSearch = model.id.toLowerCase().includes(searchTerm) ||
         (model.name && model.name.toLowerCase().includes(searchTerm));
-      return matchesProvider && matchesSearch;
+      const matchesVideo = !videoOnly || modelSupportsVideo(model.id);
+      return matchesProvider && matchesSearch && matchesVideo;
     });
 
     // Apply sorting
@@ -2162,6 +2165,9 @@ Instructions: ${systemPrompt}`;
     }
     if (ui.sortOrder) {
       ui.sortOrder.addEventListener('change', renderModelOptions);
+    }
+    if (ui.videoFilter) {
+      ui.videoFilter.addEventListener('change', renderModelOptions);
     }
     
     // Mode toggle event

--- a/static/styles.css
+++ b/static/styles.css
@@ -710,15 +710,28 @@ input[type="file"].processing::after {
 .custom-options-header {
   padding: 12px;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
   gap: 12px;
   border-bottom: 1px solid var(--border);
   background: rgba(32, 32, 32, 0.5);
 }
 
-.custom-options-header input, .custom-options-header select { 
-  width: 100%; 
+.custom-options-header input,
+.custom-options-header select {
+  width: 100%;
   padding: 8px 12px;
+  font-size: 13px;
+}
+
+.custom-options-header input[type="checkbox"] {
+  width: auto;
+}
+
+.custom-options-header .model-filter-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
   font-size: 13px;
 }
 


### PR DESCRIPTION
## Summary
- add a native video-only toggle to the model dropdown controls
- style the model selector header to accommodate the new filter
- update model filtering logic to only show video-capable models when requested

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927e3cc2ba883338a0789cdcb1d65df)