### PR TITLE
Introduce responsive two-column desktop layout with sticky controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,179 +105,185 @@
         </a>
     </header>
     <main>
-        <section class="controls">
-            <div class="field">
-                <label>OpenRouter Account</label>
-                <div class="oauth-row">
-                    <button id="btnSignIn">Sign in with OpenRouter</button>
-                    <div style="display: flex; gap: 12px; align-items: center;">
-                        <span id="authStatus" class="badge">Signed out</span>
-                        <button id="btnSignOut" disabled>Sign out</button>
-                    </div>
-                </div>
-                <div class="hint">Sign in is recommended. Manual API key entry is still available below.</div>
-            </div>
-            <div class="field">
-                <label for="apiKey">OpenRouter API Key</label>
-                <input type="password" id="apiKey" placeholder="sk-or-v1-..." autocomplete="off">
-            </div>
-            <div class="field">
-                <label for="modelId">Model</label>
-                <div class="custom-select-wrapper">
-                    <div class="custom-select">
-                        <div class="custom-select-trigger">
-                            <span id="selectedModelName">Select a model...</span>
-                            <div class="arrow"></div>
-                        </div>
-                        <div class="custom-options">
-                            <div class="custom-options-header">
-                                <select id="providerFilter">
-                                    <option value="all" selected>All</option>
-                                    <option value="google">Google</option>
-                                    <option value="openai">OpenAI</option>
-                                    <option value="anthropic">Anthropic</option>
-                                    <option value="mistralai">Mistral</option>
-                                    <option value="meta-llama">Meta</option>
-                                    <option value="qwen">Qwen</option>
-                                </select>
-                                <select id="sortOrder">
-                                    <option value="alphabetical">A-Z</option>
-                                    <option value="chronological" selected>By Release</option>
-                                </select>
-                                <input type="text" id="modelSearch" placeholder="Search models...">
-                                <label class="model-filter-toggle">
-                                    <input type="checkbox" id="videoFilter">
-                                    <span>Native video only</span>
-                                </label>
+        <div class="layout">
+            <div class="controls-column">
+                <section class="controls">
+                    <div class="field">
+                        <label>OpenRouter Account</label>
+                        <div class="oauth-row">
+                            <button id="btnSignIn">Sign in with OpenRouter</button>
+                            <div style="display: flex; gap: 12px; align-items: center;">
+                                <span id="authStatus" class="badge">Signed out</span>
+                                <button id="btnSignOut" disabled>Sign out</button>
                             </div>
-                            <div id="modelOptions" class="model-options-list"></div>
                         </div>
+                        <div class="hint">Sign in is recommended. Manual API key entry is still available below.</div>
                     </div>
-                </div>
-                <input type="hidden" id="modelId">
-            </div>
-            <div class="field reasoning-field" id="reasoningToggleField" style="display: none;">
-                <label class="switch">
-                    <input type="checkbox" id="reasoningToggle" checked>
-                    <span class="slider"></span>
-                </label>
-                <label>🧠 (Reasoning)</label>
-            </div>
-            <div class="field">
-                <label>Training Mode</label>
-                <div class="mode-switch">
-                    <label class="switch">
-                        <input type="checkbox" id="modeToggle">
-                        <span class="slider"></span>
-                    </label>
-                    <label for="modeToggle">
-                        <span id="modeLabel">Text-to-Image</span>
-                        <span class="mode-description" id="modeDescription">Generate captions describing images</span>
-                    </label>
-                </div>
-            </div>
-            <div class="field">
-                <label for="systemPrompt">System Prompt</label>
-                <textarea id="systemPrompt" rows="5" placeholder="Describe exactly how captions should be produced."></textarea>
-            </div>
-            <div class="field">
-                <label for="presetSelect">Prompt Presets</label>
-                <div class="preset-row">
-                    <select id="presetSelect"></select>
-                    <input type="text" id="presetName" placeholder="Preset name" autocomplete="off">
-                    <button id="btnSavePreset">Save Preset</button>
-                    <button id="btnDeletePreset">Delete</button>
-                </div>
-                <div class="hint">Selecting a preset fills the System Prompt. Saving stores it in your browser.</div>
-            </div>
-            <div class="field">
-                <label for="files">Upload Images/Videos</label>
-                <input type="file" id="files" accept="image/*,video/*,.txt,text/plain" multiple>
-            </div>
-
-            <div class="field" id="outputFilesField" style="display: none;">
-                <label for="outputFiles">Upload Output Images (Image-to-Image Mode)</label>
-                <input type="file" id="outputFiles" accept="image/*" multiple>
-                <div class="hint">For image-to-image mode, upload output images that correspond to your input images. Files should have matching names.</div>
-            </div>
-
-            <details class="advanced-section">
-                <summary>Advanced Options</summary>
-                <div class="advanced-content">
-                    <div class="field grid-3">
-                        <div>
-                            <label for="rps">Max RPS</label>
-                            <input type="number" id="rps" min="1" max="100" value="20">
-                        </div>
-                        <div>
-                            <label for="concurrency">Max Concurrency</label>
-                            <input type="number" id="concurrency" min="1" max="60" value="20">
-                        </div>
-                        <div>
-                            <label for="downscaleMp">Downscale Target MP</label>
-                            <input type="number" id="downscaleMp" min="0.2" max="2" step="0.1" value="1">
-                        </div>
+                    <div class="field">
+                        <label for="apiKey">OpenRouter API Key</label>
+                        <input type="password" id="apiKey" placeholder="sk-or-v1-..." autocomplete="off">
                     </div>
-                    <div class="field grid-3">
-                        <div>
-                            <label for="retryLimit">Retry Limit</label>
-                            <input type="number" id="retryLimit" min="0" max="10" value="4">
+                    <div class="field">
+                        <label for="modelId">Model</label>
+                        <div class="custom-select-wrapper">
+                            <div class="custom-select">
+                                <div class="custom-select-trigger">
+                                    <span id="selectedModelName">Select a model...</span>
+                                    <div class="arrow"></div>
+                                </div>
+                                <div class="custom-options">
+                                    <div class="custom-options-header">
+                                        <select id="providerFilter">
+                                            <option value="all" selected>All</option>
+                                            <option value="google">Google</option>
+                                            <option value="openai">OpenAI</option>
+                                            <option value="anthropic">Anthropic</option>
+                                            <option value="mistralai">Mistral</option>
+                                            <option value="meta-llama">Meta</option>
+                                            <option value="qwen">Qwen</option>
+                                        </select>
+                                        <select id="sortOrder">
+                                            <option value="alphabetical">A-Z</option>
+                                            <option value="chronological" selected>By Release</option>
+                                        </select>
+                                        <input type="text" id="modelSearch" placeholder="Search models...">
+                                        <label class="model-filter-toggle">
+                                            <input type="checkbox" id="videoFilter">
+                                            <span>Native video only</span>
+                                        </label>
+                                    </div>
+                                    <div id="modelOptions" class="model-options-list"></div>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <label for="framesPerVideo">Frames per Video</label>
-                            <input type="number" id="framesPerVideo" min="1" max="15" value="8">
+                        <input type="hidden" id="modelId">
+                    </div>
+                    <div class="field reasoning-field" id="reasoningToggleField" style="display: none;">
+                        <label class="switch">
+                            <input type="checkbox" id="reasoningToggle" checked>
+                            <span class="slider"></span>
+                        </label>
+                        <label>🧠 (Reasoning)</label>
+                    </div>
+                    <div class="field">
+                        <label>Training Mode</label>
+                        <div class="mode-switch">
+                            <label class="switch">
+                                <input type="checkbox" id="modeToggle">
+                                <span class="slider"></span>
+                            </label>
+                            <label for="modeToggle">
+                                <span id="modeLabel">Text-to-Image</span>
+                                <span class="mode-description" id="modeDescription">Generate captions describing images</span>
+                            </label>
                         </div>
                     </div>
                     <div class="field">
-                        <label class="switch">
-                            <input type="checkbox" id="useCustomVllm">
-                            <span class="slider"></span>
-                        </label>
-                        <label>Use Custom VLLM Server <span class="vllm-tooltip"><span id="vllmStatusIndicator" class="vllm-status-indicator hidden"></span><span class="vllm-tooltip-text" id="vllmStatusTooltip">Connecting to VLLM server...</span></span></label>
+                        <label for="systemPrompt">System Prompt</label>
+                        <textarea id="systemPrompt" rows="5" placeholder="Describe exactly how captions should be produced."></textarea>
                     </div>
-                    <div class="field" id="customVllmField" style="display: none;">
-                        <label for="customVllmEndpoint">VLLM Server</label>
-                        <input type="text" id="customVllmEndpoint" placeholder="192.168.1.100:8000 or example.com" autocomplete="off">
-                        <div class="hint">Enter your VLLM server (IP:port, domain, or full URL, e.g., 192.168.1.100:8000, example.com, or https://example.com)</div>
+                    <div class="field">
+                        <label for="presetSelect">Prompt Presets</label>
+                        <div class="preset-row">
+                            <select id="presetSelect"></select>
+                            <input type="text" id="presetName" placeholder="Preset name" autocomplete="off">
+                            <button id="btnSavePreset">Save Preset</button>
+                            <button id="btnDeletePreset">Delete</button>
+                        </div>
+                        <div class="hint">Selecting a preset fills the System Prompt. Saving stores it in your browser.</div>
                     </div>
-                    <div class="field" id="customVllmBearerTokenField" style="display: none;">
-                        <label for="customVllmBearerToken">Bearer Token (Optional)</label>
-                        <input type="password" id="customVllmBearerToken" placeholder="Bearer token for server authentication" autocomplete="off">
-                        <div class="hint">Enter bearer token if your VLLM server requires authentication</div>
+                    <div class="field">
+                        <label for="files">Upload Images/Videos</label>
+                        <input type="file" id="files" accept="image/*,video/*,.txt,text/plain" multiple>
                     </div>
-                    <div class="field" id="customVllmBasicAuthField" style="display: none;">
-                        <label for="customVllmUsername">Username (Optional)</label>
-                        <input type="text" id="customVllmUsername" placeholder="Username for Basic Auth" autocomplete="off">
-                        <div class="hint">Enter username for Basic Authentication if required</div>
+        
+                    <div class="field" id="outputFilesField" style="display: none;">
+                        <label for="outputFiles">Upload Output Images (Image-to-Image Mode)</label>
+                        <input type="file" id="outputFiles" accept="image/*" multiple>
+                        <div class="hint">For image-to-image mode, upload output images that correspond to your input images. Files should have matching names.</div>
                     </div>
-                    <div class="field" id="customVllmPasswordField" style="display: none;">
-                        <label for="customVllmPassword">Password (Optional)</label>
-                        <input type="password" id="customVllmPassword" placeholder="Password for Basic Auth" autocomplete="off">
-                        <div class="hint">Enter password for Basic Authentication if required</div>
+        
+                    <details class="advanced-section">
+                        <summary>Advanced Options</summary>
+                        <div class="advanced-content">
+                            <div class="field grid-3">
+                                <div>
+                                    <label for="rps">Max RPS</label>
+                                    <input type="number" id="rps" min="1" max="100" value="20">
+                                </div>
+                                <div>
+                                    <label for="concurrency">Max Concurrency</label>
+                                    <input type="number" id="concurrency" min="1" max="60" value="20">
+                                </div>
+                                <div>
+                                    <label for="downscaleMp">Downscale Target MP</label>
+                                    <input type="number" id="downscaleMp" min="0.2" max="2" step="0.1" value="1">
+                                </div>
+                            </div>
+                            <div class="field grid-3">
+                                <div>
+                                    <label for="retryLimit">Retry Limit</label>
+                                    <input type="number" id="retryLimit" min="0" max="10" value="4">
+                                </div>
+                                <div>
+                                    <label for="framesPerVideo">Frames per Video</label>
+                                    <input type="number" id="framesPerVideo" min="1" max="15" value="8">
+                                </div>
+                            </div>
+                            <div class="field">
+                                <label class="switch">
+                                    <input type="checkbox" id="useCustomVllm">
+                                    <span class="slider"></span>
+                                </label>
+                                <label>Use Custom VLLM Server <span class="vllm-tooltip"><span id="vllmStatusIndicator" class="vllm-status-indicator hidden"></span><span class="vllm-tooltip-text" id="vllmStatusTooltip">Connecting to VLLM server...</span></span></label>
+                            </div>
+                            <div class="field" id="customVllmField" style="display: none;">
+                                <label for="customVllmEndpoint">VLLM Server</label>
+                                <input type="text" id="customVllmEndpoint" placeholder="192.168.1.100:8000 or example.com" autocomplete="off">
+                                <div class="hint">Enter your VLLM server (IP:port, domain, or full URL, e.g., 192.168.1.100:8000, example.com, or https://example.com)</div>
+                            </div>
+                            <div class="field" id="customVllmBearerTokenField" style="display: none;">
+                                <label for="customVllmBearerToken">Bearer Token (Optional)</label>
+                                <input type="password" id="customVllmBearerToken" placeholder="Bearer token for server authentication" autocomplete="off">
+                                <div class="hint">Enter bearer token if your VLLM server requires authentication</div>
+                            </div>
+                            <div class="field" id="customVllmBasicAuthField" style="display: none;">
+                                <label for="customVllmUsername">Username (Optional)</label>
+                                <input type="text" id="customVllmUsername" placeholder="Username for Basic Auth" autocomplete="off">
+                                <div class="hint">Enter username for Basic Authentication if required</div>
+                            </div>
+                            <div class="field" id="customVllmPasswordField" style="display: none;">
+                                <label for="customVllmPassword">Password (Optional)</label>
+                                <input type="password" id="customVllmPassword" placeholder="Password for Basic Auth" autocomplete="off">
+                                <div class="hint">Enter password for Basic Authentication if required</div>
+                            </div>
+                        </div>
+                    </details>
+        
+                    <div class="field" style="display:flex;align-items:center;gap:12px;">
+                        <button id="btnSaveZip" disabled>Save Captions as ZIP</button>
                     </div>
-                </div>
-            </details>
-
-            <div class="field" style="display:flex;align-items:center;gap:12px;">
-                <button id="btnSaveZip" disabled>Save Captions as ZIP</button>
+        
+                    <div class="buttons">
+                        <button id="btnCaption">Caption</button>
+                        <button id="btnCaptionUncaptioned">Caption Uncaptioned</button>
+                        <button id="btnCancel" disabled>Cancel</button>
+                        <button id="btnClear">Clear</button>
+                        <button id="btnClearAllCaptions">Clear All Captions</button>
+                    </div>
+                    <div class="hint">Your API key is only used locally in this browser tab.</div>
+                </section>
             </div>
 
-            <div class="buttons">
-                <button id="btnCaption">Caption</button>
-                <button id="btnCaptionUncaptioned">Caption Uncaptioned</button>
-                <button id="btnCancel" disabled>Cancel</button>
-                <button id="btnClear">Clear</button>
-                <button id="btnClearAllCaptions">Clear All Captions</button>
+            <div class="results-column">
+                <section class="status">
+                    <div id="progressText">Idle</div>
+                    <progress id="progressBar" value="0" max="100"></progress>
+                </section>
+
+                <section id="results" class="results"></section>
             </div>
-            <div class="hint">Your API key is only used locally in this browser tab.</div>
-        </section>
-
-        <section class="status">
-            <div id="progressText">Idle</div>
-            <progress id="progressBar" value="0" max="100"></progress>
-        </section>
-
-        <section id="results" class="results"></section>
+        </div>
     </main>
     <footer>
         <a href="https://openrouter.ai" target="_blank" rel="noreferrer noopener">Powered by OpenRouter</a>
@@ -289,4 +295,3 @@
     <script src="src/script.js?v=1.1"></script>
 </body>
 </html>
-

--- a/static/styles.css
+++ b/static/styles.css
@@ -211,8 +211,18 @@ footer .separator {
 
 main { 
   padding: 32px; 
-  max-width: 1400px;
+  max-width: 100%;
   margin: 0 auto;
+}
+
+.layout {
+  display: grid;
+  gap: 24px;
+}
+
+.controls-column,
+.results-column {
+  min-width: 0;
 }
 
 .controls {
@@ -244,6 +254,19 @@ main {
   transform: translateY(-2px);
   box-shadow: var(--shadow-xl);
   border-color: var(--border-light);
+}
+
+@media (min-width: 1100px) {
+  .layout {
+    grid-template-columns: minmax(320px, 420px) 1fr;
+    gap: 32px;
+    align-items: start;
+  }
+
+  .controls {
+    position: sticky;
+    top: 24px;
+  }
 }
 
 .field {
@@ -1325,4 +1348,3 @@ textarea:focus-visible {
   visibility: visible;
   opacity: 1;
 }
-


### PR DESCRIPTION
### Motivation
- Provide a two-column desktop layout so controls/status remain visible while users scroll the results column.
- Allow the results column to expand beyond the previous `max-width` constraint so content can use available space on wide screens.
- Preserve the existing single-column stacking behavior on tablet and mobile breakpoints.

### Description
- Wrap the controls, status and results sections in a new `div.layout` and split them into `div.controls-column` and `div.results-column` in `index.html`.
- Relax `main` width by changing `max-width: 1400px` to `max-width: 100%` in `static/styles.css` so the results column can grow.
- Add responsive grid rules: at `@media (min-width: 1100px)` set `.layout { grid-template-columns: minmax(320px, 420px) 1fr; gap: 32px; align-items: start; }` so the left column is a fixed min/max and the right column fills remaining space.
- Make the `.controls` panel `position: sticky` with `top: 24px`, and add column helpers (`.controls-column`, `.results-column { min-width: 0; }`) to avoid overflow.

### Testing
- Launched a local HTTP server and ran a Playwright script to render `index.html` at a 1400×900 viewport and capture a desktop screenshot, which completed successfully.
- No automated unit tests were added or run since this is a static layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697dc6f2a083339cdb1678a2c93675)