### PR TITLE
Add `.field-group` wrappers and two-column layout for controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,44 +119,46 @@
                         </div>
                         <div class="hint">Sign in is recommended. Manual API key entry is still available below.</div>
                     </div>
-                    <div class="field">
-                        <label for="apiKey">OpenRouter API Key</label>
-                        <input type="password" id="apiKey" placeholder="sk-or-v1-..." autocomplete="off">
-                    </div>
-                    <div class="field">
-                        <label for="modelId">Model</label>
-                        <div class="custom-select-wrapper">
-                            <div class="custom-select">
-                                <div class="custom-select-trigger">
-                                    <span id="selectedModelName">Select a model...</span>
-                                    <div class="arrow"></div>
-                                </div>
-                                <div class="custom-options">
-                                    <div class="custom-options-header">
-                                        <select id="providerFilter">
-                                            <option value="all" selected>All</option>
-                                            <option value="google">Google</option>
-                                            <option value="openai">OpenAI</option>
-                                            <option value="anthropic">Anthropic</option>
-                                            <option value="mistralai">Mistral</option>
-                                            <option value="meta-llama">Meta</option>
-                                            <option value="qwen">Qwen</option>
-                                        </select>
-                                        <select id="sortOrder">
-                                            <option value="alphabetical">A-Z</option>
-                                            <option value="chronological" selected>By Release</option>
-                                        </select>
-                                        <input type="text" id="modelSearch" placeholder="Search models...">
-                                        <label class="model-filter-toggle">
-                                            <input type="checkbox" id="videoFilter">
-                                            <span>Native video only</span>
-                                        </label>
+                    <div class="field-group">
+                        <div class="field">
+                            <label for="apiKey">OpenRouter API Key</label>
+                            <input type="password" id="apiKey" placeholder="sk-or-v1-..." autocomplete="off">
+                        </div>
+                        <div class="field">
+                            <label for="modelId">Model</label>
+                            <div class="custom-select-wrapper">
+                                <div class="custom-select">
+                                    <div class="custom-select-trigger">
+                                        <span id="selectedModelName">Select a model...</span>
+                                        <div class="arrow"></div>
                                     </div>
-                                    <div id="modelOptions" class="model-options-list"></div>
+                                    <div class="custom-options">
+                                        <div class="custom-options-header">
+                                            <select id="providerFilter">
+                                                <option value="all" selected>All</option>
+                                                <option value="google">Google</option>
+                                                <option value="openai">OpenAI</option>
+                                                <option value="anthropic">Anthropic</option>
+                                                <option value="mistralai">Mistral</option>
+                                                <option value="meta-llama">Meta</option>
+                                                <option value="qwen">Qwen</option>
+                                            </select>
+                                            <select id="sortOrder">
+                                                <option value="alphabetical">A-Z</option>
+                                                <option value="chronological" selected>By Release</option>
+                                            </select>
+                                            <input type="text" id="modelSearch" placeholder="Search models...">
+                                            <label class="model-filter-toggle">
+                                                <input type="checkbox" id="videoFilter">
+                                                <span>Native video only</span>
+                                            </label>
+                                        </div>
+                                        <div id="modelOptions" class="model-options-list"></div>
+                                    </div>
                                 </div>
                             </div>
+                            <input type="hidden" id="modelId">
                         </div>
-                        <input type="hidden" id="modelId">
                     </div>
                     <div class="field reasoning-field" id="reasoningToggleField" style="display: none;">
                         <label class="switch">
@@ -183,24 +185,34 @@
                         <textarea id="systemPrompt" rows="5" placeholder="Describe exactly how captions should be produced."></textarea>
                     </div>
                     <div class="field">
-                        <label for="presetSelect">Prompt Presets</label>
-                        <div class="preset-row">
-                            <select id="presetSelect"></select>
-                            <input type="text" id="presetName" placeholder="Preset name" autocomplete="off">
-                            <button id="btnSavePreset">Save Preset</button>
-                            <button id="btnDeletePreset">Delete</button>
+                        <label>Prompt Presets</label>
+                        <div class="field-group">
+                            <div class="field">
+                                <label for="presetSelect">Preset</label>
+                                <select id="presetSelect"></select>
+                            </div>
+                            <div class="field">
+                                <label for="presetName">Preset Name</label>
+                                <div class="preset-row">
+                                    <input type="text" id="presetName" placeholder="Preset name" autocomplete="off">
+                                    <button id="btnSavePreset">Save Preset</button>
+                                    <button id="btnDeletePreset">Delete</button>
+                                </div>
+                            </div>
                         </div>
                         <div class="hint">Selecting a preset fills the System Prompt. Saving stores it in your browser.</div>
                     </div>
-                    <div class="field">
-                        <label for="files">Upload Images/Videos</label>
-                        <input type="file" id="files" accept="image/*,video/*,.txt,text/plain" multiple>
-                    </div>
-        
-                    <div class="field" id="outputFilesField" style="display: none;">
-                        <label for="outputFiles">Upload Output Images (Image-to-Image Mode)</label>
-                        <input type="file" id="outputFiles" accept="image/*" multiple>
-                        <div class="hint">For image-to-image mode, upload output images that correspond to your input images. Files should have matching names.</div>
+                    <div class="field-group">
+                        <div class="field">
+                            <label for="files">Upload Images/Videos</label>
+                            <input type="file" id="files" accept="image/*,video/*,.txt,text/plain" multiple>
+                        </div>
+            
+                        <div class="field" id="outputFilesField" style="display: none;">
+                            <label for="outputFiles">Upload Output Images (Image-to-Image Mode)</label>
+                            <input type="file" id="outputFiles" accept="image/*" multiple>
+                            <div class="hint">For image-to-image mode, upload output images that correspond to your input images. Files should have matching names.</div>
+                        </div>
                     </div>
         
                     <details class="advanced-section">

--- a/static/styles.css
+++ b/static/styles.css
@@ -267,11 +267,23 @@ main {
     position: sticky;
     top: 24px;
   }
+
+  .field-group {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .field {
   display: grid;
   gap: 8px;
+  min-width: 0;
+}
+
+.field-group {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
   min-width: 0;
 }
 
@@ -430,7 +442,7 @@ button#btnClear:hover {
 }
 .preset-row { 
   display: grid; 
-  grid-template-columns: 1fr 1fr auto auto; 
+  grid-template-columns: 1fr auto auto; 
   gap: 12px; 
   align-items: end;
 }


### PR DESCRIPTION
### Motivation
- Enable multi-column groupings for related control fields so frequently used inputs can be presented side-by-side on desktop while staying stacked on smaller screens.
- Prioritize grouping high-frequency controls together (API key + model, preset select + name + save/delete, and upload inputs) for faster access.

### Description
- Add `field-group` wrappers in `index.html` around the API key + model controls, the prompt preset controls (split into a `presetSelect` column and a `presetName` + actions column), and the upload inputs (input files + optional output files). 
- Introduce a new `.field-group` CSS rule in `static/styles.css` that defaults to a single-column grid and uses a desktop breakpoint `@media (min-width: 1100px)` to set `grid-template-columns: repeat(2, minmax(0, 1fr));` and `gap: 16px` for two-column layout.
- Adjust the preset action layout by changing `.preset-row` to `grid-template-columns: 1fr auto auto;` so the select, name, and buttons align more compactly in the new grouping.

### Testing
- Launched a local static server with `python -m http.server 8000` to serve the modified UI and verified the server started successfully. 
- Attempted an automated visual capture with Playwright to verify layout, but the Chromium process crashed in the container so the screenshot step failed. 
- No other automated tests were executed against the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697f273ddc83339b575937d1d15524)