### PR TITLE
Add results header and shared surface styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
     <main>
         <div class="layout">
             <div class="controls-column">
-                <section class="controls">
+                <section class="controls surface">
                     <div class="field">
                         <label>OpenRouter Account</label>
                         <div class="oauth-row">
@@ -288,11 +288,15 @@
             </div>
 
             <div class="results-column">
-                <section class="status">
+                <section class="status surface">
                     <div id="progressText">Idle</div>
                     <progress id="progressBar" value="0" max="100"></progress>
                 </section>
 
+                <div class="results-header surface">
+                    <h2>Results</h2>
+                    <div class="hint">Captions, previews, and exports will appear here as files finish processing.</div>
+                </div>
                 <section id="results" class="results"></section>
             </div>
         </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -225,16 +225,19 @@ main {
   min-width: 0;
 }
 
-.controls {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 24px;
+.surface {
   background: rgba(26, 26, 26, 0.9);
   backdrop-filter: var(--blur-glass);
   border: 1px solid var(--border);
   border-radius: 16px;
-  padding: 32px;
   box-shadow: var(--shadow-lg);
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 24px;
+  padding: 32px;
   position: relative;
   overflow: hidden;
   transition: all 0.3s ease;
@@ -812,7 +815,6 @@ input[type="file"].processing::after {
   padding: 16px 20px;
   background: rgba(26, 26, 26, 0.6);
   border-radius: 12px;
-  border: 1px solid var(--border);
 }
 
 progress {
@@ -844,7 +846,31 @@ progress::-moz-progress-bar {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
   gap: 24px;
-  margin-top: 32px;
+  margin-top: 20px;
+}
+
+.results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  margin-top: 16px;
+  border-top: 1px solid var(--border-light);
+  background: rgba(32, 32, 32, 0.75);
+}
+
+.results-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.results-header .hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
 }
 
 .card {
@@ -1073,6 +1099,7 @@ textarea:focus-visible {
 /* Enhanced glass effect for modern browsers */
 @supports (backdrop-filter: blur(16px)) {
   .controls,
+  .surface,
   .card,
   header,
   footer {


### PR DESCRIPTION
### Motivation

- Improve visual hierarchy between controls/status and the results area so users can more easily scan outputs. 
- Create a small, reusable surface treatment to keep controls, status, and the new header visually cohesive.

### Description

- Inserted a `div.results-header` block (with an `h2` and a `.hint`) immediately before the `section#results` element in `index.html` to label the results area. 
- Introduced a reusable `.surface` CSS class and moved shared panel styling (background, border, radius, shadow) into `.surface` in `static/styles.css`, then applied `surface` to `.controls` and `.status`. 
- Split out padding/positioning back into `.controls` so the shared surface can be reused by other blocks like `.results-header`. 
- Adjusted results spacing (`.results` margin-top) and added styling for `.results-header` (padding, subtle top border, background, typography) to separate it from controls/status.

### Testing

- Launched a local static server with `python -m http.server 8000` and served the updated `index.html`, which started successfully. 
- Ran a Playwright script that navigated to `http://127.0.0.1:8000/index.html` and captured a full-page screenshot showing the new results header, and the script completed successfully and produced `results-header.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69698abb0b7c8333b1e503ac49565441)