### PR TITLE
Add card size control near progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,8 +289,15 @@
 
             <div class="results-column">
                 <section class="status surface">
-                    <div id="progressText">Idle</div>
-                    <progress id="progressBar" value="0" max="100"></progress>
+                    <div class="progress-row">
+                        <div id="progressText">Idle</div>
+                        <progress id="progressBar" value="0" max="100"></progress>
+                    </div>
+                    <div class="card-size-control">
+                        <label for="cardSizeRange">Card size</label>
+                        <input type="range" id="cardSizeRange" min="260" max="520" step="20" value="360">
+                        <span id="cardSizeValue" aria-live="polite">360px</span>
+                    </div>
                 </section>
 
                 <div class="results-header surface">

--- a/src/script.js
+++ b/src/script.js
@@ -79,6 +79,8 @@
     customVllmPasswordField: el('customVllmPasswordField'),
     vllmStatusIndicator: el('vllmStatusIndicator'),
     vllmStatusTooltip: el('vllmStatusTooltip'),
+    cardSizeRange: el('cardSizeRange'),
+    cardSizeValue: el('cardSizeValue'),
   };
 
   // Persistent storage keys
@@ -96,7 +98,10 @@
     customVllmBearerToken: 'sc_custom_vllm_bearer_token',
     customVllmUsername: 'sc_custom_vllm_username',
     customVllmPassword: 'sc_custom_vllm_password',
+    cardSize: 'sc_card_size',
   };
+
+  const defaultCardSize = 360;
 
   // Presets helpers
   function defaultPresets() {
@@ -308,6 +313,14 @@ EXAMPLES:
     }
   }
 
+  function applyCardSize(size) {
+    const clamped = Math.max(260, Math.min(520, size));
+    if (ui.results) ui.results.style.setProperty('--card-min-width', `${clamped}px`);
+    if (ui.cardSizeValue) ui.cardSizeValue.textContent = `${clamped}px`;
+    if (ui.cardSizeRange) ui.cardSizeRange.value = String(clamped);
+    return clamped;
+  }
+
   function initPersistence() {
     // API key
     try {
@@ -418,6 +431,22 @@ EXAMPLES:
             fetchVllmModels();
           }
         }
+      });
+    }
+
+    if (ui.cardSizeRange) {
+      let startingSize = defaultCardSize;
+      try {
+        const savedSize = localStorage.getItem(storageKeys.cardSize);
+        if (savedSize) startingSize = Number.parseInt(savedSize, 10);
+      } catch { }
+      const applied = applyCardSize(Number.isNaN(startingSize) ? defaultCardSize : startingSize);
+      try { localStorage.setItem(storageKeys.cardSize, String(applied)); } catch { }
+
+      ui.cardSizeRange.addEventListener('input', () => {
+        const next = Number.parseInt(ui.cardSizeRange.value, 10);
+        const appliedValue = applyCardSize(Number.isNaN(next) ? defaultCardSize : next);
+        try { localStorage.setItem(storageKeys.cardSize, String(appliedValue)); } catch { }
       });
     }
 
@@ -2184,4 +2213,3 @@ Instructions: ${systemPrompt}`;
   // Initialize mode UI
   updateModeUI();
 })();
-

--- a/static/styles.css
+++ b/static/styles.css
@@ -810,11 +810,37 @@ input[type="file"].processing::after {
 .status { 
   margin: 24px 0; 
   display: flex; 
-  align-items: center; 
-  gap: 16px; 
+  flex-direction: column;
+  align-items: flex-start; 
+  gap: 12px; 
   padding: 16px 20px;
   background: rgba(26, 26, 26, 0.6);
   border-radius: 12px;
+}
+
+.progress-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.card-size-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.card-size-control input[type="range"] {
+  accent-color: var(--accent-color);
+  width: min(240px, 50vw);
+}
+
+.card-size-control span {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
 }
 
 progress {
@@ -843,10 +869,12 @@ progress::-moz-progress-bar {
 }
 
 .results {
+  --card-min-width: 360px;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(var(--card-min-width), 1fr));
   gap: 24px;
   margin-top: 20px;
+  transition: grid-template-columns 0.2s ease;
 }
 
 .results-header {


### PR DESCRIPTION
### Motivation

- Provide a simple UI control so users can increase or decrease the width of result cards in the Results grid.  
- Persist the chosen card size so the layout remains consistent across sessions.

### Description

- Add a slider and live value display to the status area in `index.html` with `id="cardSizeRange"` and `id="cardSizeValue"` and a default value of `360` (range `260–520`, step `20`).
- Introduce `--card-min-width` CSS variable and adapt the `.results` grid to use it, plus new `.progress-row` and `.card-size-control` styles in `static/styles.css` and make the status area stack vertically to accommodate the control.
- Wire UI elements into `src/script.js` by registering `ui.cardSizeRange` / `ui.cardSizeValue`, adding a `storageKeys.cardSize` key and `defaultCardSize`, and implementing `applyCardSize(size)` plus persistence and an `input` listener that updates the grid and saves the preference.

### Testing

- Started a local HTTP server (`python -m http.server`) and ran a Playwright script that loads `index.html`, sets the slider to `440`, dispatches an `input` event and captures a screenshot; the script completed and produced a screenshot artifact indicating the slider and layout rendered successfully.  
- No unit tests were added or executed beyond the browser automation smoke test above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a8c67c2d88333b3adbd3cd47dbcc9)