### PR TITLE
Fix caption clickability, add Tab navigation between captions, and include existing caption in AI requests

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -972,10 +972,14 @@ progress::-moz-progress-bar {
   color: var(--text-secondary);
   display: flex;
   justify-content: center;
-  align-items: flex-start;
-  overflow: hidden; /* prevent overflow */
+  align-items: stretch;
+  overflow: visible;
   min-width: 0; /* allow flexbox item to shrink */
   width: 100%; /* take full available width */
+}
+
+.media .right {
+  overflow: visible;
 }
 
 .meta { 


### PR DESCRIPTION
### Motivation
- Fix UI issue where the bottom line of caption textareas could not be clicked due to restrictive overflow/align styling. 
- Improve keyboard UX so pressing `Tab` while focused in a caption textarea advances the focus to the next caption. 
- Allow the AI to receive the current caption so it can revise or improve an existing caption when captioning or rerolling.

### Description
- Relaxed caption layout in `static/styles.css` by changing `.caption` to `align-items: stretch` and `overflow: visible`, and added `.media .right { overflow: visible; }` to ensure the bottom row is clickable. 
- Added a `right` element class in `src/script.js` when rendering cards to match the adjusted layout. 
- Implemented `getExistingCaption` and `getAdjacentCaptionTextarea` helpers and a `keydown` handler on caption textareas to intercept `Tab` and move focus to the adjacent caption textarea. 
- Pass `existingCaption` on caption requests (both in batch captioning and `rerollCaption`), and prepend a short prompt (`existingCaptionPrompt`) in `requestCaption` so the AI receives the current caption and can revise it.

### Testing
- Launched a local server with `python -m http.server 8000` and used a Playwright script to load `index.html` and capture a screenshot (`artifacts/sillycaption-ui.png`), which completed successfully. 
- No unit tests or other automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c38e6048c83338ed0cb0342c74fcf)