### PR TITLE
Improve caption card spacing and defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,8 +303,8 @@
                     </div>
                     <div class="card-size-control">
                         <label for="cardSizeRange">Card size</label>
-                        <input type="range" id="cardSizeRange" min="260" max="520" step="20" value="360">
-                        <span id="cardSizeValue" aria-live="polite">360px</span>
+                        <input type="range" id="cardSizeRange" min="260" max="520" step="20" value="400">
+                        <span id="cardSizeValue" aria-live="polite">400px</span>
                     </div>
                 </section>
 

--- a/src/script.js
+++ b/src/script.js
@@ -103,7 +103,7 @@
     includeExistingCaption: 'sc_include_existing_caption',
   };
 
-  const defaultCardSize = 360;
+  const defaultCardSize = 400;
 
   // Presets helpers
   function defaultPresets() {

--- a/static/styles.css
+++ b/static/styles.css
@@ -33,7 +33,7 @@ html {
 
 .caption textarea {
   width: 100%;
-  min-height: 80px;
+  min-height: 72px;
   max-width: 100%;
   box-sizing: border-box;
   border-radius: 8px;
@@ -42,7 +42,8 @@ html {
   color: var(--text);
   font-size: 14px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  padding: 8px 10px;
+  padding: 6px 8px;
+  line-height: 1.4;
   resize: none; /* disable manual resize */
   transition: border-color 0.2s, background 0.2s;
   margin: 0;
@@ -872,7 +873,7 @@ progress::-moz-progress-bar {
   --card-min-width: 360px;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(var(--card-min-width), 1fr));
-  gap: 24px;
+  gap: 18px;
   margin-top: 20px;
   transition: grid-template-columns 0.2s ease;
 }
@@ -937,7 +938,7 @@ progress::-moz-progress-bar {
 }
 
 .media > div { 
-  padding: 16px; 
+  padding: 12px; 
   display: grid; 
   align-content: start; 
   gap: 12px; 
@@ -963,7 +964,7 @@ progress::-moz-progress-bar {
 }
 
 .caption { 
-  padding: 8px; 
+  padding: 4px; 
   font-size: 14px; 
   line-height: 1.6; 
   white-space: pre-wrap; 
@@ -972,7 +973,7 @@ progress::-moz-progress-bar {
   color: var(--text-secondary);
   display: flex;
   justify-content: center;
-  align-items: stretch;
+  align-items: flex-start;
   overflow: visible;
   min-width: 0; /* allow flexbox item to shrink */
   width: 100%; /* take full available width */


### PR DESCRIPTION
### Motivation
- Fix a persistent UX issue where textarea bottom rows were hard to click due to over-padding and reduce visual clutter on very wide (2560×1440) displays.

### Description
- Reduce the caption textarea min-height and internal padding and add a tighter `line-height` to make the last row clickable (`static/styles.css`).
- Adjust the caption container padding and vertical alignment to remove excess internal spacing and ensure the textarea aligns to the top (`static/styles.css`).
- Reduce media/card interior padding and tighten the results grid gap to declutter wide layouts (`static/styles.css`).
- Increase the default card size from `360` to `400` and update the slider default value in the UI to better suit large monitors (`src/script.js`, `index.html`).

### Testing
- Ran a local dev server and executed a Playwright script which loaded the page at `2560×1440` and produced a screenshot saved as `artifacts/layout-update.png`, confirming the visual layout loaded successfully.
- No unit or integration test suite was present for these UI/CSS-only changes, so only the visual smoke test above was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f190a0984833394f84fa4371b571b)